### PR TITLE
Quick Hotfix for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN . /home/appuser/venv/bin/activate && \
 ENTRYPOINT [ "tini", "--" ]
 
 # Run it!
-CMD . /home/appuser/venv/bin/activate && python3 -m main.py
+CMD . /home/appuser/venv/bin/activate && python3 -m main


### PR DESCRIPTION
I remove the .py from the CMD command, because I got this while actually testing the code:
```
/home/appuser/venv/bin/python3: Error while finding module specification for 'main.py' (ModuleNotFoundError: __path__ attribute not found on 'main' while trying to find 'main.py'). Try using 'main' instead of 'main.py' as the module name.
```